### PR TITLE
edit cardlist screen’s appbar

### DIFF
--- a/lib/src/widgets/card_list_screen/card_list_screen.dart
+++ b/lib/src/widgets/card_list_screen/card_list_screen.dart
@@ -10,29 +10,30 @@ class CardListScreen extends StatelessWidget {
   Widget build(BuildContext context) => Scaffold(
         floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
         floatingActionButton: NewCardFloatingActionButton(),
+        appBar: AppBar(
+          backgroundColor: SarakaColors.white,
+          elevation: 0,
+          iconTheme: IconThemeData(color: SarakaColors.lightBlack),
+          centerTitle: true,
+          title: Text(
+            'Cards',
+            style: SarakaTextStyles.appBarTitle.copyWith(
+              color: SarakaColors.lightBlack,
+            ),
+          ),
+          leading: Navigator.of(context).canPop()
+              ? IconButton(
+                  icon: Icon(Feather.getIconData('arrow-left')),
+                  onPressed: () => Navigator.of(context).pop(),
+                )
+              : null,
+        ),
         body: Container(
           child: Stack(
             children: [
               WaveBackground(),
               CustomScrollView(
                 slivers: [
-                  SliverAppBar(
-                    backgroundColor: Color(0x00000000),
-                    iconTheme: IconThemeData(color: SarakaColors.lightBlack),
-                    centerTitle: true,
-                    title: Text(
-                      'Cards',
-                      style: SarakaTextStyles.appBarTitle.copyWith(
-                        color: SarakaColors.lightBlack,
-                      ),
-                    ),
-                    leading: Navigator.of(context).canPop()
-                        ? IconButton(
-                            icon: Icon(Feather.getIconData('arrow-left')),
-                            onPressed: () => Navigator.of(context).pop(),
-                          )
-                        : null,
-                  ),
                   SliverPadding(
                     padding: EdgeInsets.fromLTRB(16, 16, 16, 80),
                     sliver: CardSliverList(),


### PR DESCRIPTION
@axross Can you check this change? The appbar used to be hidden when the user scrolls the card list.